### PR TITLE
Fix deprecation warning

### DIFF
--- a/tasks/repository.yml
+++ b/tasks/repository.yml
@@ -2,11 +2,10 @@
 ---
 - name: repository | install dependencies (pre)
   apt:
-    name: "{{ item }}"
+    name: "{{ yarn_dependencies_pre }}"
     state: "{{ apt_install_state | default('latest') }}"
     update_cache: true
     cache_valid_time: "{{ apt_update_cache_valid_time | default(3600) }}"
-  with_items: "{{ yarn_dependencies_pre }}"
   tags:
     - yarn-repository-install-dependencies
 


### PR DESCRIPTION
Warning:
```
 TASK [oefenweb.yarn : repository | install dependencies (pre)] *****************
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: {{ item }}`, please use `name: '{{ yarn_dependencies_pre
}}'` and remove the loop. This feature will be removed in version 2.11.
Deprecation warnings can be disabled by setting deprecation_warnings=False in
ansible.cfg.
```

ansible 2.7.1
python 3.7.0