### PR TITLE
Fix deprecation warning

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,8 +2,7 @@
 ---
 - name: install | dependencies
   apt:
-    name: "{{ item }}"
+    name: "{{ yarn_dependencies }}"
     state: "{{ apt_install_state | default('latest') }}"
-  with_items: "{{ yarn_dependencies }}"
   tags:
     - yarn-install-dependencies


### PR DESCRIPTION
 Warning:
```
TASK [oefenweb.yarn : install | dependencies] **********************************
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via
squash_actions is deprecated. Instead of using a loop to supply multiple items
and specifying `name: {{ item }}`, please use `name: '{{ yarn_dependencies }}'`
 and remove the loop. This feature will be removed in version 2.11. Deprecation
 warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

ansible 2.7.1
python 3.7.0