### PR TITLE
Travis test also for python 3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,12 @@ dist: trusty
 language: python
 python:
   - "2.7"
-  - "3.7"
+# Enable 3.7 without globally enabling sudo and dist: xenial for other build jobs
+matrix:
+  include:
+    - python: 3.7
+      dist: xenial
+      sudo: true
 
 env:
   - ANSIBLE_VERSION=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ sudo: required
 dist: trusty
 
 language: python
-python: "2.7"
+python:
+  - "2.7"
+  - "3.7"
 
 env:
   - ANSIBLE_VERSION=latest
@@ -26,21 +28,6 @@ env:
   - ANSIBLE_VERSION=2.5.2
   - ANSIBLE_VERSION=2.5.1
   - ANSIBLE_VERSION=2.5.0
-  - ANSIBLE_VERSION=2.4.6.0
-  - ANSIBLE_VERSION=2.4.5.0
-  - ANSIBLE_VERSION=2.4.4.0
-  - ANSIBLE_VERSION=2.4.3.0
-  - ANSIBLE_VERSION=2.4.2.0
-  - ANSIBLE_VERSION=2.4.1.0
-  - ANSIBLE_VERSION=2.4.0.0
-  - ANSIBLE_VERSION=2.3.3.0
-  - ANSIBLE_VERSION=2.3.2.0
-  - ANSIBLE_VERSION=2.3.1.0
-  - ANSIBLE_VERSION=2.3.0.0
-  - ANSIBLE_VERSION=2.2.3.0
-  - ANSIBLE_VERSION=2.2.2.0
-  - ANSIBLE_VERSION=2.2.1.0
-  - ANSIBLE_VERSION=2.2.0.0
 
 branches:
   only:


### PR DESCRIPTION
Test the code also for the new python version 3.7
And drop support for Ansible 2.4 and lower to improve test speed.

This is a more a PR suggestion, would like to know your opinion 😄 